### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on version tags like v1.0.0, v2.1.3, etc.
+    branches:
+      - main  # Triggers on pushes to main branch
+  workflow_dispatch:  # Allows manual triggering from GitHub UI
+    inputs:
+      tag_name:
+        description: 'Tag name for the release'
+        required: true
+        default: 'v1.0.0'
+      release_name:
+        description: 'Release name'
+        required: false
+        default: ''
+      prerelease:
+        description: 'Mark as pre-release'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history for proper changelog generation
+    
+    - name: Set release variables
+      id: vars
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "tag_name=${{ github.event.inputs.tag_name }}" >> $GITHUB_OUTPUT
+          echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+          echo "prerelease=${{ github.event.inputs.prerelease }}" >> $GITHUB_OUTPUT
+        elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          # Tagged release
+          echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "release_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "prerelease=false" >> $GITHUB_OUTPUT
+        else
+          # Push to main branch - create pre-release with timestamp
+          timestamp=$(date +'%Y%m%d-%H%M%S')
+          short_sha=${GITHUB_SHA::7}
+          echo "tag_name=dev-${timestamp}-${short_sha}" >> $GITHUB_OUTPUT
+          echo "release_name=Development Build ${timestamp}" >> $GITHUB_OUTPUT
+          echo "prerelease=true" >> $GITHUB_OUTPUT
+        fi
+        
+        # Set release name to tag if empty (for manual trigger)
+        if [ -z "${{ github.event.inputs.release_name }}" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          echo "release_name=${{ github.event.inputs.tag_name }}" >> $GITHUB_OUTPUT
+        fi
+    
+    - name: Create release zip
+      id: create_zip
+      run: |
+        # Create a clean directory for the release
+        mkdir -p release-build
+        
+        # Copy all files except .git, .github, and other development files
+        rsync -av --progress . release-build/ \
+          --exclude='.git*' \
+          --exclude='.github/' \
+          --exclude='node_modules/' \
+          --exclude='*.log' \
+          --exclude='.DS_Store' \
+          --exclude='Thumbs.db' \
+          --exclude='release-build/'
+        
+        # Create the zip file
+        cd release-build
+        zip -r "../ha-roku-cast-${{ steps.vars.outputs.tag_name }}.zip" .
+        cd ..
+        
+        # Get file size for release notes
+        file_size=$(stat -c%s "ha-roku-cast-${{ steps.vars.outputs.tag_name }}.zip")
+        echo "zip_size=$file_size" >> $GITHUB_OUTPUT
+        echo "zip_filename=ha-roku-cast-${{ steps.vars.outputs.tag_name }}.zip" >> $GITHUB_OUTPUT
+    
+    - name: Generate changelog
+      id: changelog
+      run: |
+        # Simple changelog generation - you can enhance this
+        echo "## Changes" > CHANGELOG.md
+        echo "" >> CHANGELOG.md
+        
+        if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          # Tagged release changelog
+          if git describe --tags --abbrev=0 HEAD^ >/dev/null 2>&1; then
+            last_tag=$(git describe --tags --abbrev=0 HEAD^)
+            echo "Changes since $last_tag:" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log --pretty=format:"- %s (%an)" $last_tag..HEAD >> CHANGELOG.md
+          else
+            echo "Initial release" >> CHANGELOG.md
+          fi
+        elif [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+          # Development build from main branch
+          echo "**⚠️ Development Build** - This is a pre-release build from the main branch." >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "Recent changes:" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          git log --pretty=format:"- %s (%an)" -10 >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "**Commit:** \`${GITHUB_SHA::7}\`" >> CHANGELOG.md
+        else
+          # Manual workflow dispatch
+          echo "Manual release" >> CHANGELOG.md
+        fi
+        
+        echo "" >> CHANGELOG.md
+        echo "## Installation" >> CHANGELOG.md
+        echo "" >> CHANGELOG.md
+        echo "1. Download the \`${{ steps.create_zip.outputs.zip_filename }}\` file" >> CHANGELOG.md
+        echo "2. Extract to your Roku development environment" >> CHANGELOG.md
+        echo "3. Side-load to your Roku device using the Roku Developer Tools" >> CHANGELOG.md
+        echo "" >> CHANGELOG.md
+        echo "**File Size:** $(numfmt --to=iec ${{ steps.create_zip.outputs.zip_size }})" >> CHANGELOG.md
+        
+        # Set output for release body
+        {
+          echo 'release_body<<EOF'
+          cat CHANGELOG.md
+          echo EOF
+        } >> $GITHUB_OUTPUT
+    
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.vars.outputs.tag_name }}
+        name: ${{ steps.vars.outputs.release_name }}
+        body: ${{ steps.changelog.outputs.release_body }}
+        files: ${{ steps.create_zip.outputs.zip_filename }}
+        prerelease: ${{ steps.vars.outputs.prerelease == 'true' }}
+        draft: false
+        generate_release_notes: false  # We're providing our own notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Upload release artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-zip
+        path: ${{ steps.create_zip.outputs.zip_filename }}
+        retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,24 +39,60 @@ jobs:
           echo "tag_name=${{ github.event.inputs.tag_name }}" >> $GITHUB_OUTPUT
           echo "release_name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
           echo "prerelease=${{ github.event.inputs.prerelease }}" >> $GITHUB_OUTPUT
+          echo "version_type=manual" >> $GITHUB_OUTPUT
         elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-          # Tagged release
-          echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          echo "release_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          # Tagged release - can be major, minor, or patch
+          tag_name=${GITHUB_REF#refs/tags/}
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+          echo "release_name=$tag_name" >> $GITHUB_OUTPUT
           echo "prerelease=false" >> $GITHUB_OUTPUT
+          echo "version_type=tagged" >> $GITHUB_OUTPUT
         else
-          # Push to main branch - create pre-release with timestamp
-          timestamp=$(date +'%Y%m%d-%H%M%S')
-          short_sha=${GITHUB_SHA::7}
-          echo "tag_name=dev-${timestamp}-${short_sha}" >> $GITHUB_OUTPUT
-          echo "release_name=Development Build ${timestamp}" >> $GITHUB_OUTPUT
-          echo "prerelease=true" >> $GITHUB_OUTPUT
+          # Push to main branch - auto-bump patch version
+          echo "version_type=patch_bump" >> $GITHUB_OUTPUT
+          
+          # Get the latest tag (if any) to determine next patch version
+          if git describe --tags --abbrev=0 >/dev/null 2>&1; then
+            latest_tag=$(git describe --tags --abbrev=0)
+            echo "Latest tag found: $latest_tag"
+            
+            # Extract version numbers (remove 'v' prefix if present)
+            version=${latest_tag#v}
+            
+            # Split version into major.minor.patch
+            IFS='.' read -r major minor patch <<< "$version"
+            
+            # Increment patch version
+            new_patch=$((patch + 1))
+            new_version="v${major}.${minor}.${new_patch}"
+          else
+            # No tags exist, start with v0.0.1
+            new_version="v0.0.1"
+            echo "No previous tags found, starting with $new_version"
+          fi
+          
+          echo "tag_name=$new_version" >> $GITHUB_OUTPUT
+          echo "release_name=$new_version (Auto Patch)" >> $GITHUB_OUTPUT
+          echo "prerelease=false" >> $GITHUB_OUTPUT
         fi
         
         # Set release name to tag if empty (for manual trigger)
         if [ -z "${{ github.event.inputs.release_name }}" ] && [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           echo "release_name=${{ github.event.inputs.tag_name }}" >> $GITHUB_OUTPUT
         fi
+    
+    - name: Create and push auto-generated tag (for main branch pushes)
+      if: steps.vars.outputs.version_type == 'patch_bump'
+      run: |
+        # Configure git for the action
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
+        # Create the new tag
+        git tag ${{ steps.vars.outputs.tag_name }}
+        git push origin ${{ steps.vars.outputs.tag_name }}
+        
+        echo "Created and pushed tag: ${{ steps.vars.outputs.tag_name }}"
     
     - name: Create release zip
       id: create_zip
@@ -87,11 +123,10 @@ jobs:
     - name: Generate changelog
       id: changelog
       run: |
-        # Simple changelog generation - you can enhance this
         echo "## Changes" > CHANGELOG.md
         echo "" >> CHANGELOG.md
         
-        if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+        if [ "${{ steps.vars.outputs.version_type }}" = "tagged" ]; then
           # Tagged release changelog
           if git describe --tags --abbrev=0 HEAD^ >/dev/null 2>&1; then
             last_tag=$(git describe --tags --abbrev=0 HEAD^)
@@ -101,16 +136,29 @@ jobs:
           else
             echo "Initial release" >> CHANGELOG.md
           fi
-        elif [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
-          # Development build from main branch
-          echo "**⚠️ Development Build** - This is a pre-release build from the main branch." >> CHANGELOG.md
+          
+        elif [ "${{ steps.vars.outputs.version_type }}" = "patch_bump" ]; then
+          # Auto patch bump from main branch
+          echo "**🔄 Automatic Patch Release** - Auto-incremented from main branch push." >> CHANGELOG.md
           echo "" >> CHANGELOG.md
-          echo "Recent changes:" >> CHANGELOG.md
+          
+          # Show changes since last tag
+          if git describe --tags --abbrev=0 HEAD^ >/dev/null 2>&1; then
+            last_tag=$(git describe --tags --abbrev=0 HEAD^)
+            echo "Changes since $last_tag:" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log --pretty=format:"- %s (%an)" $last_tag..HEAD >> CHANGELOG.md
+          else
+            echo "Recent changes:" >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+            git log --pretty=format:"- %s (%an)" -10 >> CHANGELOG.md
+          fi
+          
           echo "" >> CHANGELOG.md
-          git log --pretty=format:"- %s (%an)" -10 >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
+          echo "**Note:** This version was automatically created from a push to main. For major or minor version changes, create a git tag manually." >> CHANGELOG.md
           echo "" >> CHANGELOG.md
           echo "**Commit:** \`${GITHUB_SHA::7}\`" >> CHANGELOG.md
+          
         else
           # Manual workflow dispatch
           echo "Manual release" >> CHANGELOG.md


### PR DESCRIPTION
I noticed your v1 release isn't lined up with what's on main right now, here's an action to keep them in sync.

Push tags to bump any version, eg push majors or minors with this snippet:

```
git tag v2.0.0
git push origin v2.0.0
```

Any pushes to main will automatically build the next patch release.